### PR TITLE
Coerce candidates to string before highlighting

### DIFF
--- a/helm-flx.el
+++ b/helm-flx.el
@@ -111,9 +111,15 @@ candidates is greater than this number, only sort the first N (presorted by leng
                       (> (cdr c1)
                          (cdr c2))))))))
 
+(defun helm-flx-candidate-string (candidate)
+  (cond
+   ((symbolp candidate) (symbol-name candidate))
+   (t candidate)))
+
 (defun helm-flx-fuzzy-highlight-match (candidate)
   (require 'flx)
-  (let* ((pair (and (consp candidate) candidate))
+  (let* ((candidate (helm-flx-candidate-string candidate))
+         (pair (and (consp candidate) candidate))
          (display (if pair (car pair) candidate))
          (real (cdr pair)))
     (with-temp-buffer


### PR DESCRIPTION
Some helm sources, such as the `helm-themes` package, use symbols in
their candidates list, which would break the assumption that they are
chars or stings somehwere in `helm-flx-fuzzy-highlight-match`.

This adds a coercion function `helm-flx-candidate-string` that converts
a symbol to a string -- with a cond statement, so this can be extended
to other types, though I'm not sure this would come up in practice? --
and ensures that candidates are strings in the scope of the highlighting
function.

This PR fixes #5 
