### PR TITLE
Remove eval-when-compile for using package functions

### DIFF
--- a/helm-flx.el
+++ b/helm-flx.el
@@ -37,10 +37,8 @@
 
 ;;; Code:
 
-(eval-when-compile
-  (with-demoted-errors "Byte-compile: %s"
-    (require 'helm)
-    (require 'flx)))
+(require 'helm)
+(require 'flx)
 
 (defgroup helm-flx nil
   "Sort helm candidates by flx score"


### PR DESCRIPTION
Fix following byte-compile warnings.

```
helm-flx.el:243:1:Warning: the following functions might not be defined at runtime:
    flx-make-filename-cache, flx-score,
    helm-fuzzy-matching-default-sort-fn,
    helm-fuzzy-default-highlight-match, helm-basename
```