### PR TITLE
Fix after breaking change in Helm

### DIFF
--- a/helm-flx.el
+++ b/helm-flx.el
@@ -178,10 +178,10 @@ Return candidates prefixed with basename of `helm-input' first."
          (1+ index) (+ 2 index) '(face helm-match))))
     (buffer-string)))
 
-(defun helm-flx-fuzzy-highlight-match (candidate)
+(defun helm-flx-fuzzy-highlight-match (candidate &optional diacritics)
   (require 'flx)
   (if (string-match-p " " helm-pattern)
-      (helm-fuzzy-default-highlight-match candidate)
+      (helm-fuzzy-default-highlight-match candidate diacritics)
     (let* ((candidate (helm-flx-candidate-string candidate))
            (pair (and (consp candidate) candidate))
            (display (if pair (car pair) candidate))


### PR DESCRIPTION
See [this discussion](https://github.com/emacs-helm/helm/commit/16ab10d4b8213594e09c3164025c57a6fe9c6cf6#r70173993). `helm-fuzzy-matching-highlight-fn` now has to support an optional second argument.